### PR TITLE
Keep the features placeholder out of site queries

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,6 +10,7 @@ exports.createPages = ({ actions, graphql }) => {
   return graphql(`
     {
       allMarkdownRemark(
+        filter: { frontmatter: { title: { ne: "Features placeholder" } } }
         sort: { fields: [frontmatter___date], order: DESC }
         limit: 1000
       ) {
@@ -23,7 +24,12 @@ exports.createPages = ({ actions, graphql }) => {
           }
         }
       }
-      posts: allFile(filter: { sourceInstanceName: { eq: "posts" } }) {
+      posts: allFile(
+        filter: {
+          sourceInstanceName: { eq: "posts" }
+          name: { ne: ".features-placeholder" }
+        }
+      ) {
         edges {
           node {
             childMarkdownRemark {


### PR DESCRIPTION
# What this PR Contains
This is largely a fix for a problem I was having as I was playing around with your starter (it's fantastic - _thank you_, by the way!).  I was finding that after some light modifications to the theme, the `features placeholder` file was being read and turned into navigable posts.  This was only really problematic because it was going to get indexed by google's crawlers eventually, and the buttons pointing to older posts seemed to find that placeholder on occasion.

Caveat emptor: I'm very new to Gatsby, and fairly new to GraphQL, so this may be complete nonsense... but I did find that the changes here seemed to work for me.

FWIW - most of what caused this for me seemed to be wanting to group my `posts` into subdirectories under the `posts` folder:

![image](https://user-images.githubusercontent.com/1844496/53351395-3c35aa80-38ef-11e9-860c-9d5efb2029de.png)

So it's possible that these issues are completely of my own doing.  I'd love to hear what you think!

_PS - you can check the repo for my site [here](https://github.com/mbifulco/blog), and the site itself is currently deployed at [https://mike.biful.co](https://mike.biful.co).  Thanks again for providing a great starter!_