### PR TITLE
fix deprecation warnings

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -130,11 +130,11 @@ exports.sourceNodes = ({ actions }) => {
     type Frontmatter {
       title: String!
       author: String
-      date: Date!
+      date: Date! @dateformat
       path: String!
       tags: [String!]
       excerpt: String
-      coverImage: File
+      coverImage: File @fileByRelativePath
     }
   `
   createTypes(typeDefs)


### PR DESCRIPTION
Running gatsby develop or build on the current version of code produces two deprecation warnings:
```
warn Deprecation warning - adding inferred resolver for field Frontmatter.date. In Gatsby v3, only fields with an explicit directive/extension will get a resolver.
warn Deprecation warning - adding inferred resolver for field Frontmatter.coverImage. In Gatsby v3, only fields with an explicit directive/extension will get a resolver.
```
This PR fixes these warnings.

See this for reference: https://www.gatsbyjs.org/blog/2019-05-17-improvements-to-schema-customization/#resolver-extensions

Thanks for this awesome starter theme!